### PR TITLE
Put 'salad' in front of directories

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -5,8 +5,8 @@ from tqdm import tqdm
 import argparse
 
 
-from vpr_model import VPRModel
-from utils.validation import get_validation_recalls
+from salad.vpr_model import VPRModel
+from salad.utils.validation import get_validation_recalls
 # Dataloader
 #from dataloaders.val.NordlandDataset import NordlandDataset
 #from dataloaders.val.MapillaryDataset import MSLS

--- a/models_salad/helper.py
+++ b/models_salad/helper.py
@@ -1,6 +1,6 @@
 import numpy as np
-from models_salad import aggregators
-from models_salad import backbones
+from salad.models_salad import aggregators
+from salad.models_salad import backbones
 
 
 def get_backbone(

--- a/vpr_model.py
+++ b/vpr_model.py
@@ -2,8 +2,8 @@ import pytorch_lightning as pl
 import torch
 from torch.optim import lr_scheduler, optimizer
 
-import utils
-from models_salad import helper
+import salad.utils as utils
+from salad.models_salad import helper
 
 
 class VPRModel(pl.LightningModule):


### PR DESCRIPTION
~After I checked the `README.md`, most `salad` codes are not found in the VGGT-SLAM codes.~

~As we set `salad` in front of them, it might be resolved, but there might be some better ways to tackle this issue (I suspect that the salad module was not installed properly as an independent package.)~

While testing VGGT-SLAM, I encountered an import error stating that `eval` (and other modules) could not be found (which is mentioned [here](https://github.com/MIT-SPARK/VGGT-SLAM/issues/2)).

 After investigating, I found that this issue was due to missing the `salad.` prefix in several import statements.

